### PR TITLE
#22 Fix ktlint errors in website example files

### DIFF
--- a/src/test/kotlin/website/AdvancedExamples.kt
+++ b/src/test/kotlin/website/AdvancedExamples.kt
@@ -5,7 +5,6 @@ package website
 import com.pambrose.srcref.Api.srcrefUrl
 
 object AdvancedExamples {
-
   // --8<-- [start:bottom-up-last-brace]
   // Find the last closing brace in a file (useful for end of class/object)
   val lastBrace =

--- a/src/test/kotlin/website/ApiExamples.kt
+++ b/src/test/kotlin/website/ApiExamples.kt
@@ -5,7 +5,6 @@ package website
 import com.pambrose.srcref.Api.srcrefUrl
 
 object ApiExamples {
-
   // --8<-- [start:basic-usage]
   val url =
     srcrefUrl(

--- a/src/test/kotlin/website/DeploymentExamples.kt
+++ b/src/test/kotlin/website/DeploymentExamples.kt
@@ -3,7 +3,6 @@
 package website
 
 object DeploymentExamples {
-
   // --8<-- [start:docker-run]
   // docker run -p 8080:8080 \
   //   -e PORT=8080 \

--- a/src/test/kotlin/website/GradleExamples.kt
+++ b/src/test/kotlin/website/GradleExamples.kt
@@ -3,7 +3,6 @@
 package website
 
 object GradleExamples {
-
   // --8<-- [start:gradle-kotlin]
   // build.gradle.kts
   // dependencies {

--- a/src/test/kotlin/website/RegexExamples.kt
+++ b/src/test/kotlin/website/RegexExamples.kt
@@ -5,7 +5,6 @@ package website
 import com.pambrose.srcref.Api.srcrefUrl
 
 object RegexExamples {
-
   // --8<-- [start:literal-string]
   // Match a literal string — no special regex characters needed
   val literalMatch =

--- a/src/test/kotlin/website/UrlExamples.kt
+++ b/src/test/kotlin/website/UrlExamples.kt
@@ -3,7 +3,6 @@
 package website
 
 object UrlExamples {
-
   // --8<-- [start:web-single-line]
   // Highlight a single line containing "fun main" in Main.kt:
   // https://www.srcref.com/github?account=pambrose&repo=srcref&branch=master&path=src/main/kotlin/com/pambrose/srcref/Main.kt&bregex=fun+main&boccur=1&boffset=0&btopd=true


### PR DESCRIPTION
## Summary

- Remove empty first lines in class bodies across all 6 website example files, fixing `no-empty-first-line-in-class-body` ktlint errors that caused the Tests workflow to fail

## Test plan

- [ ] Verify Tests workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)