### PR TITLE
#26 Bump to 2.0.6, fix Makefile paths and add signing targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Tests in `src/test/kotlin/` use Kotest `StringSpec` with JUnit5 runner:
 
 ## Version Management
 
-Version is defined in `build.gradle.kts` (`version = "2.0.5"`). The Makefile `VERSION` is derived automatically from
+Version is defined in `build.gradle.kts` (`version = "2.0.6"`). The Makefile `VERSION` is derived automatically from
 `build.gradle.kts`. `README.md` must still be updated manually when changing the version. (Note: the comment in
 `build.gradle.kts` saying to update the Makefile is outdated — only README.md needs a manual update.)
 

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ kdocs:
 	./gradlew dokkaGeneratePublicationHtml
 
 clean-docs:
-	rm -rf website/agentmail4k/site
-	rm -rf website/agentmail4k/.cache
+	rm -rf website/srcref/site
+	rm -rf website/srcref/.cache
 
 site: clean-docs
 	cd website/srcref && uv run zensical serve
@@ -73,7 +73,17 @@ site: clean-docs
 publish-local:
 	./gradlew publishToMavenLocal
 
+publish-local-snapshot:
+	./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenLocal
+
+publish-snapshot:
+	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
+	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w) \
+	./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenCentral
+
 publish-maven-central:
+	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
+	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w) \
 	./gradlew publishAndReleaseToMavenCentral
 
 upgrade-wrapper:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ _srcref_ URLs can be generated programmatically with the `srcrefUrl()` call. An 
 
 ```kotlin
 dependencies {
-   implementation("com.pambrose:srcref:2.0.5")
+   implementation("com.pambrose:srcref:2.0.6")
 }
 ```
 
@@ -111,7 +111,7 @@ dependencies {
 
 ```groovy
 dependencies {
-   implementation 'com.pambrose:srcref:2.0.5'
+   implementation 'com.pambrose:srcref:2.0.6'
 }
 ```
 
@@ -125,7 +125,7 @@ dependencies {
 <dependency>
    <groupId>com.pambrose</groupId>
    <artifactId>srcref</artifactId>
-   <version>2.0.5</version>
+   <version>2.0.6</version>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 // Change the version in README.md as well
-version = "2.0.5"
+version = "2.0.6"
 group = "com.pambrose"
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
 

--- a/website/srcref/docs/api.md
+++ b/website/srcref/docs/api.md
@@ -13,7 +13,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
 
     ```kotlin
     dependencies {
-        implementation("com.pambrose:srcref:2.0.5")
+        implementation("com.pambrose:srcref:2.0.6")
     }
     ```
 
@@ -21,7 +21,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
 
     ```groovy
     dependencies {
-        implementation 'com.pambrose:srcref:2.0.5'
+        implementation 'com.pambrose:srcref:2.0.6'
     }
     ```
 
@@ -31,7 +31,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
     <dependency>
         <groupId>com.pambrose</groupId>
         <artifactId>srcref</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </dependency>
     ```
 


### PR DESCRIPTION
## Summary

- Bump version to 2.0.6 in `build.gradle.kts`, `README.md`, `CLAUDE.md`, and `website/srcref/docs/api.md`
- Fix `clean-docs` Makefile target paths (was referencing `agentmail4k` instead of `srcref`)
- Add `publish-local-snapshot` and `publish-snapshot` Makefile targets
- Add GPG signing key extraction via `GPG_SIGNING_KEY_ID` env var to publish targets

## Test plan

- [ ] Verify `make publish-local` works
- [ ] Verify version references are consistent across all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)