### PR TITLE
#28 Bump to 2.0.7 and support overrideVersion for snapshots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Tests in `src/test/kotlin/` use Kotest `StringSpec` with JUnit5 runner:
 
 ## Version Management
 
-Version is defined in `build.gradle.kts` (`version = "2.0.6"`). The Makefile `VERSION` is derived automatically from
+Version is defined in `build.gradle.kts` (`version = "2.0.7"`). The Makefile `VERSION` is derived automatically from
 `build.gradle.kts`. `README.md` must still be updated manually when changing the version. (Note: the comment in
 `build.gradle.kts` saying to update the Makefile is outdated — only README.md needs a manual update.)
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ _srcref_ URLs can be generated programmatically with the `srcrefUrl()` call. An 
 
 ```kotlin
 dependencies {
-   implementation("com.pambrose:srcref:2.0.6")
+   implementation("com.pambrose:srcref:2.0.7")
 }
 ```
 
@@ -111,7 +111,7 @@ dependencies {
 
 ```groovy
 dependencies {
-   implementation 'com.pambrose:srcref:2.0.6'
+   implementation 'com.pambrose:srcref:2.0.7'
 }
 ```
 
@@ -125,7 +125,7 @@ dependencies {
 <dependency>
    <groupId>com.pambrose</groupId>
    <artifactId>srcref</artifactId>
-   <version>2.0.6</version>
+   <version>2.0.7</version>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 // Change the version in README.md as well
-version = "2.0.6"
+version = findProperty("overrideVersion")?.toString() ?: "2.0.7"
 group = "com.pambrose"
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
 

--- a/website/srcref/docs/api.md
+++ b/website/srcref/docs/api.md
@@ -13,7 +13,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
 
     ```kotlin
     dependencies {
-        implementation("com.pambrose:srcref:2.0.6")
+        implementation("com.pambrose:srcref:2.0.7")
     }
     ```
 
@@ -21,7 +21,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
 
     ```groovy
     dependencies {
-        implementation 'com.pambrose:srcref:2.0.6'
+        implementation 'com.pambrose:srcref:2.0.7'
     }
     ```
 
@@ -31,7 +31,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
     <dependency>
         <groupId>com.pambrose</groupId>
         <artifactId>srcref</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.7</version>
     </dependency>
     ```
 

--- a/website/srcref/docs/getting-started.md
+++ b/website/srcref/docs/getting-started.md
@@ -67,7 +67,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
 
     ```kotlin
     dependencies {
-        implementation("com.pambrose:srcref:2.0.6")
+        implementation("com.pambrose:srcref:2.0.7")
     }
     ```
 
@@ -75,7 +75,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
 
     ```groovy
     dependencies {
-        implementation 'com.pambrose:srcref:2.0.6'
+        implementation 'com.pambrose:srcref:2.0.7'
     }
     ```
 
@@ -85,7 +85,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
     <dependency>
         <groupId>com.pambrose</groupId>
         <artifactId>srcref</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.7</version>
     </dependency>
     ```
 


### PR DESCRIPTION
## Summary

- Bump version to 2.0.7 (2.0.6 was accidentally published as a release instead of a snapshot)
- Add `findProperty("overrideVersion")` to `build.gradle.kts` so `make publish-snapshot` correctly publishes with `-SNAPSHOT` suffix
- Update version references in README.md, CLAUDE.md, api.md, and getting-started.md

## Test plan

- [ ] Verify `./gradlew properties -q | grep version` shows `2.0.7`
- [ ] Verify `./gradlew properties -q -PoverrideVersion=2.0.7-SNAPSHOT | grep version` shows `2.0.7-SNAPSHOT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)