### PR TITLE
#29 Replace deprecated maven-publish API and clean up Urls.kt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -76,10 +78,12 @@ dokka {
 }
 
 mavenPublishing {
-  configure(com.vanniktech.maven.publish.KotlinJvm(
-    javadocJar = com.vanniktech.maven.publish.JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
-    sourcesJar = true,
-  ))
+  configure(
+    com.vanniktech.maven.publish.KotlinJvm(
+      javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
+      sourcesJar = SourcesJar.Sources(),
+    ),
+  )
   coordinates("com.pambrose", "srcref", version.toString())
 
   pom {
@@ -106,7 +110,7 @@ mavenPublishing {
     }
   }
 
-  publishToMavenCentral()
+  publishToMavenCentral(automaticRelease = true)
   signAllPublications()
 }
 

--- a/src/main/kotlin/com/pambrose/srcref/Urls.kt
+++ b/src/main/kotlin/com/pambrose/srcref/Urls.kt
@@ -18,8 +18,10 @@ import com.pambrose.srcref.QueryParams.END_REGEX
 import com.pambrose.srcref.QueryParams.END_TOPDOWN
 import com.pambrose.srcref.QueryParams.PATH
 import com.pambrose.srcref.QueryParams.REPO
+import com.pambrose.srcref.Urls.calcLineNumber
 import com.pambrose.srcref.pages.Common.hasValues
 import java.util.regex.PatternSyntaxException
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTimedValue
 import org.apache.commons.text.StringEscapeUtils.escapeHtml4
 
@@ -32,7 +34,7 @@ import org.apache.commons.text.StringEscapeUtils.escapeHtml4
 object Urls {
   internal const val MSG = "msg"
   internal const val RAW_PREFIX = "https://raw.githubusercontent.com"
-  private const val REGEX_TIMEOUT_NANOS = 5_000_000_000L // 5 seconds
+  private val REGEX_TIMEOUT_NANOS = 5.seconds.inWholeNanoseconds
 
   /**
    * Converts this parameter map to a URL-encoded query string.


### PR DESCRIPTION
## Summary

- Replace deprecated `sourcesJar = true` with `SourcesJar.Sources()` in vanniktech maven-publish config
- Add explicit imports for `JavadocJar` and `SourcesJar`
- Add `automaticRelease = true` to `publishToMavenCentral()`
- Replace hardcoded `REGEX_TIMEOUT_NANOS` constant with `5.seconds.inWholeNanoseconds` in Urls.kt

## Test plan

- [ ] Verify `./gradlew build` passes
- [ ] Verify `make publish-local` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)