### PR TITLE
#30 Extract GPG_ENV in Makefile and skip signing without GPG key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,15 +76,15 @@ publish-local:
 publish-local-snapshot:
 	./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenLocal
 
-publish-snapshot:
+GPG_ENV = \
 	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
-	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w) \
-	./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenCentral
+	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)
+
+publish-snapshot:
+	$(GPG_ENV) ./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenCentral
 
 publish-maven-central:
-	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
-	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w) \
-	./gradlew publishAndReleaseToMavenCentral
+	$(GPG_ENV) ./gradlew publishAndReleaseToMavenCentral
 
 upgrade-wrapper:
 	./gradlew wrapper --gradle-version=9.4.1 --distribution-type=bin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,3 +114,7 @@ mavenPublishing {
   signAllPublications()
 }
 
+// Skip signing when no GPG key is provided (e.g., local publishing)
+tasks.withType<Sign>().configureEach {
+  isEnabled = project.findProperty("signingInMemoryKey") != null
+}


### PR DESCRIPTION
## Summary

- Extract repeated GPG signing environment variables into a shared `GPG_ENV` variable in Makefile, used by both `publish-snapshot` and `publish-maven-central`
- Skip signing tasks when no GPG key is provided, allowing `make publish-local` to work without GPG setup

## Test plan

- [ ] Verify `make publish-local` works without GPG key
- [ ] Verify `make publish-maven-central` still signs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)