### PR TITLE
Migrate common-utils from JitPack to Maven Central and bump dependencies (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # srcref - Dynamic Line-Specific GitHub Permalinks
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/pambrose/srcref)
-[![Kotlin version](https://img.shields.io/badge/kotlin-2.2.20-red?logo=kotlin)](http://kotlinlang.org)
-[![Maven Central](https://img.shields.io/maven-central/v/com.pambrose/srcref)](https://central.sonatype.com/artifact/com.pambrose/srcref)
+[![Maven Central](https://img.shields.io/maven-central/v/com.pambrose/srcref)](https://central.sonatype.com/artifact/com.pambrose.srcref)
+[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.20-red?logo=kotlin)](http://kotlinlang.org)
+[![ktlint](https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081)](https://pinterest.github.io/ktlint/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## Overview

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,10 +7,8 @@ plugins {
   alias(libs.plugins.kotlin)
   alias(libs.plugins.buildconfig)
   alias(libs.plugins.ktor)
-  alias(libs.plugins.pambrose.envvar)
   alias(libs.plugins.pambrose.stable.versions)
   alias(libs.plugins.pambrose.kotlinter)
-  alias(libs.plugins.pambrose.snapshot)
   alias(libs.plugins.pambrose.testing)
   alias(libs.plugins.dokka)
   alias(libs.plugins.maven.publish)
@@ -32,16 +30,17 @@ application {
   mainClass = "com.pambrose.srcref.Main"
 }
 
+repositories {
+  // mavenLocal()
+  google()
+  mavenCentral()
+}
+
 dependencies {
   implementation(libs.kotlin.coroutines)
 
-  implementation(platform(libs.ktor.bom))
   implementation(libs.bundles.ktor)
-
-//  implementation(platform(libs.utils.bom))
   implementation(libs.bundles.common.utils)
-
-  implementation(platform(libs.dropwizard.bom))
   implementation(libs.bundles.dropwizard)
 
   implementation(libs.commons.text)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Plugins
 kotlin = "2.3.20"
 buildconfig = "6.0.9"
-gradle-plugins = "1.0.11"
+gradle-plugins = "1.0.12"
 dokka = "2.2.0"
 maven-publish = "0.36.0"
 
@@ -14,14 +14,13 @@ ktor = "3.4.2"
 logback = "1.5.32"
 logging = "8.0.01"
 text = "1.15.0"
-utils = "2.6.4"
+utils = "2.7.0"
 
 [libraries]
 # Kotlin
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 
 # Ktor
-ktor-bom = { module = "io.ktor:ktor-bom", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
 ktor-server-html = { module = "io.ktor:ktor-server-html-builder", version.ref = "ktor" }
@@ -29,12 +28,10 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 
 # Utils
-# utils-bom = { module = "com.github.pambrose.common-utils:common-utils-bom", version.ref = "utils" }
-utils-core = { module = "com.github.pambrose.common-utils:core-utils", version.ref = "utils" }
-utils-ktor-server = { module = "com.github.pambrose.common-utils:ktor-server-utils", version.ref = "utils" }
+utils-core = { module = "com.pambrose.common-utils:core-utils", version.ref = "utils" }
+utils-ktor-server = { module = "com.pambrose.common-utils:ktor-server-utils", version.ref = "utils" }
 
 # Metrics
-dropwizard-bom = { module = "io.dropwizard.metrics:metrics-bom", version.ref = "dropwizard" }
 dropwizard-core = { module = "io.dropwizard.metrics:metrics-core", version.ref = "dropwizard" }
 dropwizard-jvm = { module = "io.dropwizard.metrics:metrics-jvm", version.ref = "dropwizard" }
 
@@ -53,10 +50,8 @@ kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
-pambrose-envvar = { id = "com.pambrose.envvar", version.ref = "gradle-plugins" }
 pambrose-stable-versions = { id = "com.pambrose.stable-versions", version.ref = "gradle-plugins" }
 pambrose-kotlinter = { id = "com.pambrose.kotlinter", version.ref = "gradle-plugins" }
-pambrose-snapshot = { id = "com.pambrose.snapshot", version.ref = "gradle-plugins" }
 pambrose-testing = { id = "com.pambrose.testing", version.ref = "gradle-plugins" }
 
 [bundles]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,30 +1,5 @@
-pluginManagement {
-  resolutionStrategy {
-    eachPlugin {
-      if (requested.id.namespace == "com.pambrose") {
-        useModule("com.github.pambrose:pambrose-gradle-plugins:${requested.version}")
-      }
-    }
-  }
-
-  repositories {
-    maven("https://jitpack.io")
-    gradlePluginPortal()
-  }
-}
-
 plugins {
   id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
-
-dependencyResolutionManagement {
-  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-  repositories {
-    google()
-    mavenCentral()
-    maven { url = uri("https://jitpack.io") }
-  }
-}
-
 
 rootProject.name = "srcref"

--- a/src/main/kotlin/com/pambrose/srcref/ContentCache.kt
+++ b/src/main/kotlin/com/pambrose/srcref/ContentCache.kt
@@ -1,7 +1,7 @@
 package com.pambrose.srcref
 
-import com.github.pambrose.common.util.isNotNull
-import com.github.pambrose.common.util.simpleClassName
+import com.pambrose.common.util.isNotNull
+import com.pambrose.common.util.simpleClassName
 import com.pambrose.srcref.Urls.RAW_PREFIX
 import com.pambrose.srcref.Urls.toInt
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/src/main/kotlin/com/pambrose/srcref/Main.kt
+++ b/src/main/kotlin/com/pambrose/srcref/Main.kt
@@ -1,8 +1,8 @@
 package com.pambrose.srcref
 
-import com.github.pambrose.common.util.Version
-import com.github.pambrose.common.util.Version.Companion.versionDesc
-import com.github.pambrose.common.util.getBanner
+import com.pambrose.common.util.Version
+import com.pambrose.common.util.Version.Companion.versionDesc
+import com.pambrose.common.util.getBanner
 import com.pambrose.srcref.Endpoints.PING
 import com.pambrose.srcref.Main.excludedEndpoints
 import com.pambrose.srcref.Routes.configureRoutes

--- a/src/main/kotlin/com/pambrose/srcref/Routes.kt
+++ b/src/main/kotlin/com/pambrose/srcref/Routes.kt
@@ -1,7 +1,7 @@
 package com.pambrose.srcref
 
 import com.codahale.metrics.jvm.ThreadDump
-import com.github.pambrose.common.response.redirectTo
+import com.pambrose.common.response.redirectTo
 import com.pambrose.srcref.Endpoints.CACHE
 import com.pambrose.srcref.Endpoints.EDIT
 import com.pambrose.srcref.Endpoints.GITHUB

--- a/src/main/kotlin/com/pambrose/srcref/Urls.kt
+++ b/src/main/kotlin/com/pambrose/srcref/Urls.kt
@@ -1,7 +1,7 @@
 package com.pambrose.srcref
 
-import com.github.pambrose.common.util.encode
-import com.github.pambrose.common.util.isNotNull
+import com.pambrose.common.util.encode
+import com.pambrose.common.util.isNotNull
 import com.pambrose.srcref.ContentCache.Companion.fetchContent
 import com.pambrose.srcref.Endpoints.GITHUB
 import com.pambrose.srcref.Endpoints.PROBLEM


### PR DESCRIPTION
## Summary
- Migrate `common-utils` from JitPack (`com.github.pambrose`) to Maven Central (`com.pambrose`)
- Bump `gradle-plugins` 1.0.11 → 1.0.12 and `common-utils` 2.6.4 → 2.7.0
- Remove BOM dependencies (`ktor-bom`, `dropwizard-bom`) in favor of explicit versions already specified in the version catalog
- Remove unused plugins (`envvar`, `snapshot`) and simplify `settings.gradle.kts` by removing JitPack repository and `pluginManagement` block
- Update README badges: Kotlin 2.3.20, add ktlint badge, fix Maven Central badge URL

## Test plan
- [ ] Verify `./gradlew build -xtest` succeeds
- [ ] Verify `./gradlew test` passes all tests
- [ ] Verify `./gradlew lintKotlin` passes
- [ ] Verify the dev server starts with `./gradlew run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)