### PR TITLE
Configure Gradle daemon JVM memory to fix metaspace exhaustion (#32)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 org.gradle.configuration-cache=true
-#org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m -Xss10m -Dkotlin.daemon.jvm.options=-Xss10m
+org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m -Xss10m -Dkotlin.daemon.jvm.options=-Xss10m


### PR DESCRIPTION
## Summary
- Enable `org.gradle.jvmargs` in `gradle.properties` to configure 1 GiB heap and 1 GiB metaspace for the Gradle daemon
- Fixes the "Daemon will expire after running out of JVM Metaspace" warning during publishing tasks

## Test plan
- [ ] Verify `./gradlew build -xtest` succeeds without metaspace warning
- [ ] Verify `make publish-local` completes without daemon restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)