### PR TITLE
Remove navigation tabs from docs site config (#34)

### DIFF
--- a/website/srcref/zensical.toml
+++ b/website/srcref/zensical.toml
@@ -45,8 +45,6 @@ features = [
   "navigation.instant.progress",
   "navigation.path",
   "navigation.sections",
-  "navigation.tabs",
-  "navigation.tabs.sticky",
   "navigation.top",
   "navigation.tracking",
   "search.highlight",


### PR DESCRIPTION
## Summary
- Remove `navigation.tabs` and `navigation.tabs.sticky` features from `website/srcref/zensical.toml` to simplify the docs site navigation layout

## Test plan
- [ ] Verify docs site builds correctly without navigation tabs
- [ ] Confirm navigation layout renders as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)