### PR TITLE
Prep 2.0.9 (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project. Format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [2.0.9](https://github.com/pambrose/srcref/releases/tag/2.0.9) — 2026-04-24
+## [2.0.9](https://github.com/pambrose/srcref/releases/tag/2.0.9) — 2026-04-25
 
 - Bump version to 2.0.9
 - Bump dependencies: Kotlin 2.3.21, Ktor 3.4.3, common-utils 2.8.1
@@ -11,6 +11,9 @@ All notable changes to this project. Format is loosely based on [Keep a Changelo
 - Add `local-build`, `local-tests`, and `fatjar` Makefile targets
 - Replace `.map` with `.forEach` for the Kotlin opt-in language settings loop
 - Import `KotlinJvm` instead of using fully-qualified name in `mavenPublishing` configuration
+- Make build reproducible via `-PreleaseDate` and `-PbuildTime` Gradle property overrides
+- Add explicit `pluginManagement { repositories { ... } }` block to `settings.gradle.kts`
+- Enable Gradle build cache (`org.gradle.caching=true`)
 
 **Full Changelog**: https://github.com/pambrose/srcref/compare/2.0.8...2.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project. Format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.0.9](https://github.com/pambrose/srcref/releases/tag/2.0.9) — 2026-04-24
+
+- Bump version to 2.0.9
+- Bump dependencies: Kotlin 2.3.21, Ktor 3.4.3, common-utils 2.8.1
+- Move `repositories {}` to `settings.gradle.kts` via `dependencyResolutionManagement` with `FAIL_ON_PROJECT_REPOS`
+- Gate `mavenLocal()` behind `-PuseMavenLocal=true` for opt-in local-artifact resolution
+- Add `local-build`, `local-tests`, and `fatjar` Makefile targets
+- Replace `.map` with `.forEach` for the Kotlin opt-in language settings loop
+- Import `KotlinJvm` instead of using fully-qualified name in `mavenPublishing` configuration
+
+**Full Changelog**: https://github.com/pambrose/srcref/compare/2.0.8...2.0.9
+
 ## [2.0.8](https://github.com/pambrose/srcref/releases/tag/2.0.8) — 2026-04-16
 
 - Configure Gradle daemon JVM memory to fix metaspace exhaustion ([#32](https://github.com/pambrose/srcref/pull/32))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Tests in `src/test/kotlin/` use Kotest `StringSpec` with JUnit5 runner:
 
 ## Version Management
 
-Version is defined in `build.gradle.kts` (`version = "2.0.8"`). The Makefile `VERSION` is derived automatically from
+Version is defined in `build.gradle.kts` (`version = "2.0.9"`). The Makefile `VERSION` is derived automatically from
 `build.gradle.kts`. `README.md` must still be updated manually when changing the version. (Note: the comment in
 `build.gradle.kts` saying to update the Makefile is outdated — only README.md needs a manual update.)
 
@@ -119,7 +119,9 @@ Published to Maven Central as `com.pambrose:srcref` via the vanniktech maven-pub
 Dokka generates the javadoc jar from KDoc comments. Signing uses in-memory GPG keys via `signingInMemoryKey`,
 `signingInMemoryKeyId`, and `signingInMemoryKeyPassword` Gradle properties.
 
-- `make publish-local` — publish to `~/.m2/repository` for local testing.
+- `make publish-local` — publish to `~/.m2/repository` for local testing. To consume locally-published
+  artifacts in another build, run with `-PuseMavenLocal=true` (the `mavenLocal()` repo is gated on this
+  property in `settings.gradle.kts`).
 - `make publish-maven-central` — publish and release to Maven Central.
 - `make kdocs` — generate KDoc HTML documentation to `build/dokka/html/`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,8 +102,15 @@ Tests in `src/test/kotlin/` use Kotest `StringSpec` with JUnit5 runner:
 ## Version Management
 
 Version is defined in `build.gradle.kts` (`version = "2.0.9"`). The Makefile `VERSION` is derived automatically from
-`build.gradle.kts`. `README.md` must still be updated manually when changing the version. (Note: the comment in
-`build.gradle.kts` saying to update the Makefile is outdated — only README.md needs a manual update.)
+`build.gradle.kts`. The following must still be updated manually when changing the version:
+
+- `README.md` (Maven/Gradle dependency snippets and Kotlin version badge)
+- `website/srcref/docs/api.md` (dependency snippets)
+- `website/srcref/docs/getting-started.md` (dependency snippets)
+- `CHANGELOG.md` and `RELEASE_NOTES.md` (new version section)
+
+The build is reproducible: pass `-PreleaseDate=MM/dd/yyyy` and `-PbuildTime=<epoch-ms>` to override the values
+embedded in `BuildConfig`. Without overrides they default to "now".
 
 ## Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,16 @@ clean:
 	./gradlew clean
 
 build:	clean
-	./gradlew build -x test
+	./gradlew build -xtest
+
+local-build: clean
+	./gradlew build -PuseMavenLocal=true -xtest
+
+tests:
+	./gradlew --rerun-tasks check
+
+local-tests:
+	./gradlew --rerun-tasks -PuseMavenLocal=true check
 
 run:
 	./gradlew run
@@ -19,10 +28,10 @@ run:
 refresh:
 	./gradlew --refresh-dependencies
 
-tests:
-	./gradlew --rerun-tasks check
+fatjar: build
+	./gradlew buildFatJar
 
-uber: build
+uber: uberjar
 	java -jar build/libs/srcref-all.jar
 
 run-docker:

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ clean:
 	./gradlew clean
 
 build:	clean
-	./gradlew build -xtest
+	./gradlew build -PreleaseDate=2026-04-25 -xtest
 
 local-build: clean
-	./gradlew build -PuseMavenLocal=true -xtest
+	./gradlew build -PuseMavenLocal=true -PreleaseDate=2026-04-25 -xtest
 
 tests:
 	./gradlew --rerun-tasks check

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ _srcref_ URLs can be generated programmatically with the `srcrefUrl()` call. An 
 
 ```kotlin
 dependencies {
-   implementation("com.pambrose:srcref:2.0.8")
+   implementation("com.pambrose:srcref:2.0.9")
 }
 ```
 
@@ -113,7 +113,7 @@ dependencies {
 
 ```groovy
 dependencies {
-   implementation 'com.pambrose:srcref:2.0.8'
+   implementation 'com.pambrose:srcref:2.0.9'
 }
 ```
 
@@ -127,7 +127,7 @@ dependencies {
 <dependency>
    <groupId>com.pambrose</groupId>
    <artifactId>srcref</artifactId>
-   <version>2.0.8</version>
+   <version>2.0.9</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/pambrose/srcref?sort=semver)](https://github.com/pambrose/srcref/releases/latest)
 [![Maven Central](https://img.shields.io/maven-central/v/com.pambrose/srcref)](https://central.sonatype.com/artifact/com.pambrose/srcref)
 [![Tests](https://img.shields.io/github/actions/workflow/status/pambrose/srcref/tests.yml?branch=master&label=tests)](https://github.com/pambrose/srcref/actions/workflows/tests.yml)
-[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.20-red?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.21-red?logo=kotlin)](http://kotlinlang.org)
 [![ktlint](https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081)](https://pinterest.github.io/ktlint/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,20 @@
 
 Full release notes for every published version, newest first. Mirrors https://github.com/pambrose/srcref/releases.
 
+## [v2.0.9](https://github.com/pambrose/srcref/releases/tag/2.0.9) — 2026-04-24
+
+## What's Changed
+
+- Bump version to 2.0.9
+- Bump dependencies: Kotlin 2.3.21, Ktor 3.4.3, common-utils 2.8.1
+- Move `repositories {}` to `settings.gradle.kts` via `dependencyResolutionManagement` with `FAIL_ON_PROJECT_REPOS`
+- Gate `mavenLocal()` behind `-PuseMavenLocal=true` for opt-in local-artifact resolution
+- Add `local-build`, `local-tests`, and `fatjar` Makefile targets
+- Replace `.map` with `.forEach` for the Kotlin opt-in language settings loop
+- Import `KotlinJvm` instead of using fully-qualified name in `mavenPublishing` configuration
+
+**Full Changelog**: https://github.com/pambrose/srcref/compare/2.0.8...2.0.9
+
 ## [v2.0.8](https://github.com/pambrose/srcref/releases/tag/2.0.8) — 2026-04-16
 
 ## What's Changed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Full release notes for every published version, newest first. Mirrors https://github.com/pambrose/srcref/releases.
 
-## [v2.0.9](https://github.com/pambrose/srcref/releases/tag/2.0.9) — 2026-04-24
+## [v2.0.9](https://github.com/pambrose/srcref/releases/tag/2.0.9) — 2026-04-25
 
 ## What's Changed
 
@@ -13,6 +13,9 @@ Full release notes for every published version, newest first. Mirrors https://gi
 - Add `local-build`, `local-tests`, and `fatjar` Makefile targets
 - Replace `.map` with `.forEach` for the Kotlin opt-in language settings loop
 - Import `KotlinJvm` instead of using fully-qualified name in `mavenPublishing` configuration
+- Make build reproducible via `-PreleaseDate` and `-PbuildTime` Gradle property overrides
+- Add explicit `pluginManagement { repositories { ... } }` block to `settings.gradle.kts`
+- Enable Gradle build cache (`org.gradle.caching=true`)
 
 **Full Changelog**: https://github.com/pambrose/srcref/compare/2.0.8...2.0.9
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.SourcesJar
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -15,7 +16,7 @@ plugins {
 }
 
 // Change the version in README.md as well
-version = findProperty("overrideVersion")?.toString() ?: "2.0.8"
+version = findProperty("overrideVersion")?.toString() ?: "2.0.9"
 group = "com.pambrose"
 
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
@@ -29,11 +30,6 @@ buildConfig {
 
 application {
   mainClass = "com.pambrose.srcref.Main"
-}
-
-repositories {
-  // mavenLocal()
-  mavenCentral()
 }
 
 dependencies {
@@ -57,7 +53,7 @@ kotlin {
       "kotlin.time.ExperimentalTime",
       "kotlinx.coroutines.DelicateCoroutinesApi",
       "kotlin.concurrent.atomics.ExperimentalAtomicApi",
-    ).map { languageSettings.optIn(it) }
+    ).forEach { languageSettings.optIn(it) }
   }
 }
 
@@ -77,7 +73,7 @@ dokka {
 
 mavenPublishing {
   configure(
-    com.vanniktech.maven.publish.KotlinJvm(
+    KotlinJvm(
       javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
       sourcesJar = SourcesJar.Sources(),
     ),

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,17 +15,19 @@ plugins {
   alias(libs.plugins.maven.publish)
 }
 
-// Change the version in README.md as well
+// Update version refs in README.md and website/srcref/docs/{api,getting-started}.md as well
 version = findProperty("overrideVersion")?.toString() ?: "2.0.9"
 group = "com.pambrose"
 
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
+val releaseDate = (findProperty("releaseDate") as? String) ?: LocalDate.now().format(formatter)
+val buildTime = (findProperty("buildTime") as? String)?.toLong() ?: System.currentTimeMillis()
 
 buildConfig {
   buildConfigField("String", "NAME", "\"${project.name}\"")
   buildConfigField("String", "VERSION", "\"${project.version}\"")
-  buildConfigField("String", "RELEASE_DATE", "\"${LocalDate.now().format(formatter)}\"")
-  buildConfigField("long", "BUILD_TIME", "${System.currentTimeMillis()}L")
+  buildConfigField("String", "RELEASE_DATE", "\"$releaseDate\"")
+  buildConfigField("long", "BUILD_TIME", "${buildTime}L")
 }
 
 application {
@@ -78,7 +80,6 @@ mavenPublishing {
       sourcesJar = SourcesJar.Sources(),
     ),
   )
-  coordinates("com.pambrose", "srcref", version.toString())
 
   pom {
     name.set("srcref")
@@ -105,10 +106,8 @@ mavenPublishing {
   }
 
   publishToMavenCentral(automaticRelease = true)
-  signAllPublications()
-}
-
-// Skip signing when no GPG key is provided (e.g., local publishing)
-tasks.withType<Sign>().configureEach {
-  isEnabled = project.findProperty("signingInMemoryKey") != null
+  // Skip signing when no GPG key is provided (e.g., local publishing)
+  if (project.findProperty("signingInMemoryKey") != null) {
+    signAllPublications()
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 kotlin.code.style=official
 org.gradle.configuration-cache=true
+org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m -Xss10m -Dkotlin.daemon.jvm.options=-Xss10m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Plugins
-kotlin = "2.3.20"
+kotlin = "2.3.21"
 buildconfig = "6.0.9"
 gradle-plugins = "1.0.12"
 dokka = "2.2.0"
@@ -10,11 +10,11 @@ maven-publish = "0.36.0"
 coroutines = "1.10.2"
 dropwizard = "4.2.38"
 kotest = "6.1.11"
-ktor = "3.4.2"
+ktor = "3.4.3"
 logback = "1.5.32"
 logging = "8.0.01"
 text = "1.15.0"
-utils = "2.7.1"
+utils = "2.8.1"
 
 [libraries]
 # Kotlin
@@ -44,16 +44,6 @@ kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = 
 kotest = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 
-[plugins]
-buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
-kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
-pambrose-stable-versions = { id = "com.pambrose.stable-versions", version.ref = "gradle-plugins" }
-pambrose-kotlinter = { id = "com.pambrose.kotlinter", version.ref = "gradle-plugins" }
-pambrose-testing = { id = "com.pambrose.testing", version.ref = "gradle-plugins" }
-
 [bundles]
 ktor = [
   "ktor-server-core",
@@ -72,3 +62,13 @@ dropwizard = [
   "dropwizard-core",
   "dropwizard-jvm",
 ]
+
+[plugins]
+buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
+pambrose-stable-versions = { id = "com.pambrose.stable-versions", version.ref = "gradle-plugins" }
+pambrose-kotlinter = { id = "com.pambrose.kotlinter", version.ref = "gradle-plugins" }
+pambrose-testing = { id = "com.pambrose.testing", version.ref = "gradle-plugins" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Plugins
 kotlin = "2.3.21"
 buildconfig = "6.0.9"
-gradle-plugins = "1.0.12"
+gradle-plugins = "1.0.14"
 dokka = "2.2.0"
 maven-publish = "0.36.0"
 

--- a/llms.txt
+++ b/llms.txt
@@ -57,7 +57,8 @@ Available on Maven Central as `com.pambrose:srcref`. Licensed under Apache Licen
 ## Documentation
 
 - [GitHub Repository](https://github.com/pambrose/srcref): Source code and documentation
-- [KDoc API Reference](https://github.com/pambrose/srcref): Generated via Dokka
+- [Documentation Site](https://pambrose.github.io/srcref/): Zensical-based docs (getting started, query parameters, regex guide, API, advanced usage, deployment)
+- [KDoc API Reference](https://pambrose.github.io/srcref/api-docs/index.html): Generated via Dokka
 
 ## Optional
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,10 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+  }
+}
+
 plugins {
   id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,4 +2,14 @@ plugins {
   id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
 
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    mavenCentral()
+    if (providers.gradleProperty("useMavenLocal").orNull == "true") {
+      mavenLocal()
+    }
+  }
+}
+
 rootProject.name = "srcref"

--- a/website/srcref/docs/api.md
+++ b/website/srcref/docs/api.md
@@ -13,7 +13,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
 
     ```kotlin
     dependencies {
-        implementation("com.pambrose:srcref:2.0.8")
+        implementation("com.pambrose:srcref:2.0.9")
     }
     ```
 
@@ -21,7 +21,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
 
     ```groovy
     dependencies {
-        implementation 'com.pambrose:srcref:2.0.8'
+        implementation 'com.pambrose:srcref:2.0.9'
     }
     ```
 
@@ -31,7 +31,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
     <dependency>
         <groupId>com.pambrose</groupId>
         <artifactId>srcref</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </dependency>
     ```
 

--- a/website/srcref/docs/getting-started.md
+++ b/website/srcref/docs/getting-started.md
@@ -67,7 +67,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
 
     ```kotlin
     dependencies {
-        implementation("com.pambrose:srcref:2.0.8")
+        implementation("com.pambrose:srcref:2.0.9")
     }
     ```
 
@@ -75,7 +75,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
 
     ```groovy
     dependencies {
-        implementation 'com.pambrose:srcref:2.0.8'
+        implementation 'com.pambrose:srcref:2.0.9'
     }
     ```
 
@@ -85,7 +85,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
     <dependency>
         <groupId>com.pambrose</groupId>
         <artifactId>srcref</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </dependency>
     ```
 


### PR DESCRIPTION
## Summary
- Bump dependencies and restructure repository configuration for 2.0.9
- Make build reproducible via `releaseDate` / `buildTime` Gradle property overrides
- Add explicit `pluginManagement` repositories block and enable Gradle build cache

## Test plan
- [ ] `./gradlew build` succeeds
- [ ] `./gradlew test` passes
- [ ] `make publish-local` produces a usable artifact
- [ ] Verify reproducible build with `-PreleaseDate=... -PbuildTime=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)