### PR TITLE
Add Kover coverage with Codecov reporting (#37)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,4 +13,9 @@ jobs:
           distribution: temurin
           java-version: 17
       - uses: gradle/actions/setup-gradle@v4
-      - run: ./gradlew check
+      - run: ./gradlew check koverXmlReport
+      - uses: codecov/codecov-action@v5
+        with:
+          files: build/reports/kover/report.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@ at https://www.srcref.com.
 ./gradlew formatKotlin         # Auto-format code
 ./gradlew run                  # Run dev server (port 8080)
 ./gradlew buildFatJar          # Create fat JAR at build/libs/srcref-all.jar
+./gradlew koverHtmlReport      # Run tests + generate HTML coverage report at build/reports/kover/html/
+./gradlew koverXmlReport       # Run tests + generate XML coverage report (for CI tools)
+./gradlew koverVerify          # Run tests + verify coverage rules
 ./gradlew dependencyUpdates    # Check for dependency updates
 ```
 
@@ -34,7 +37,8 @@ Run a single named test (Kotest string spec name):
 ```
 
 Makefile shortcuts: `make build`, `make tests`, `make run`, `make uber`, `make release`, `make deploy`,
-`make kdocs`, `make publish-local`, `make publish-maven-central`.
+`make kdocs`, `make coverage`, `make coverage-xml`, `make coverage-verify`, `make publish-local`,
+`make publish-maven-central`.
 Default `make` target runs `./gradlew dependencyUpdates` to check for outdated dependencies.
 
 ## Architecture
@@ -101,8 +105,8 @@ Tests in `src/test/kotlin/` use Kotest `StringSpec` with JUnit5 runner:
 
 ## Version Management
 
-Version is defined in `build.gradle.kts` (`version = "2.0.9"`). The Makefile `VERSION` is derived automatically from
-`build.gradle.kts`. The following must still be updated manually when changing the version:
+Version is defined in `gradle.properties` (`version=2.0.10`). The Makefile `VERSION` is derived automatically from
+`gradle.properties`. The following must still be updated manually when changing the version:
 
 - `README.md` (Maven/Gradle dependency snippets and Kotlin version badge)
 - `website/srcref/docs/api.md` (dependency snippets)

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ clean:
 	./gradlew clean
 
 build:	clean
-	./gradlew build -PreleaseDate=04/25/2026 -xtest
+	./gradlew build -xtest
 
 local-build: clean
-	./gradlew build -PuseMavenLocal=true -PreleaseDate=04/25/2026 -xtest
+	./gradlew build -PuseMavenLocal=true -xtest
 
 tests:
 	./gradlew --rerun-tasks check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=$(shell grep '^version =' build.gradle.kts | head -1 | sed 's/.*"\(.*\)"/\1/')
+VERSION=$(shell grep '^version=' gradle.properties | head -1 | cut -d= -f2)
 
 default: versioncheck
 
@@ -72,6 +72,15 @@ versioncheck:
 kdocs:
 	./gradlew dokkaGeneratePublicationHtml
 
+coverage:
+	./gradlew koverHtmlReport
+
+coverage-xml:
+	./gradlew koverXmlReport
+
+coverage-verify:
+	./gradlew koverVerify
+
 clean-docs:
 	rm -rf website/srcref/site
 	rm -rf website/srcref/.cache
@@ -89,10 +98,21 @@ GPG_ENV = \
 	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
 	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)
 
-publish-snapshot:
+check-gpg-env:
+	@if [ -z "$$GPG_SIGNING_KEY_ID" ]; then \
+		echo "Error: GPG_SIGNING_KEY_ID is not set" >&2; exit 1; \
+	fi
+	@if ! gpg --list-secret-keys "$$GPG_SIGNING_KEY_ID" >/dev/null 2>&1; then \
+		echo "Error: no GPG secret key found for GPG_SIGNING_KEY_ID=$$GPG_SIGNING_KEY_ID" >&2; exit 1; \
+	fi
+	@if ! security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w >/dev/null 2>&1; then \
+		echo "Error: keychain entry 'gradle-signing-password' (account 'gpg-signing') not found" >&2; exit 1; \
+	fi
+
+publish-snapshot: check-gpg-env
 	$(GPG_ENV) ./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenCentral
 
-publish-maven-central:
+publish-maven-central: check-gpg-env
 	$(GPG_ENV) ./gradlew publishAndReleaseToMavenCentral
 
 upgrade-wrapper:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/pambrose/srcref?sort=semver)](https://github.com/pambrose/srcref/releases/latest)
 [![Maven Central](https://img.shields.io/maven-central/v/com.pambrose/srcref)](https://central.sonatype.com/artifact/com.pambrose/srcref)
 [![Tests](https://img.shields.io/github/actions/workflow/status/pambrose/srcref/tests.yml?branch=master&label=tests)](https://github.com/pambrose/srcref/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/gh/pambrose/srcref/branch/master/graph/badge.svg)](https://codecov.io/gh/pambrose/srcref)
 [![Kotlin version](https://img.shields.io/badge/kotlin-2.3.21-red?logo=kotlin)](http://kotlinlang.org)
 [![ktlint](https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081)](https://pinterest.github.io/ktlint/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ _srcref_ URLs can be generated programmatically with the `srcrefUrl()` call. An 
 
 ```kotlin
 dependencies {
-   implementation("com.pambrose:srcref:2.0.9")
+   implementation("com.pambrose:srcref:2.0.10")
 }
 ```
 
@@ -113,7 +113,7 @@ dependencies {
 
 ```groovy
 dependencies {
-   implementation 'com.pambrose:srcref:2.0.9'
+   implementation 'com.pambrose:srcref:2.0.10'
 }
 ```
 
@@ -127,7 +127,7 @@ dependencies {
 <dependency>
    <groupId>com.pambrose</groupId>
    <artifactId>srcref</artifactId>
-   <version>2.0.9</version>
+   <version>2.0.10</version>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,11 +17,11 @@ plugins {
 }
 
 // Version and group are defined in gradle.properties; also update version refs in README.md and website/srcref/docs/{api,getting-started}.md
-findProperty("overrideVersion")?.toString()?.let { version = it }
+providers.gradleProperty("overrideVersion").orNull?.let { version = it }
 
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
-val releaseDate = (findProperty("releaseDate") as? String) ?: LocalDate.now().format(formatter)
-val buildTime = (findProperty("buildTime") as? String)?.toLong() ?: System.currentTimeMillis()
+val releaseDate = providers.gradleProperty("releaseDate").orNull ?: LocalDate.now().format(formatter)
+val buildTime = providers.gradleProperty("buildTime").orNull?.toLong() ?: System.currentTimeMillis()
 
 buildConfig {
   buildConfigField("String", "NAME", "\"${project.name}\"")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,12 +12,12 @@ plugins {
   alias(libs.plugins.pambrose.kotlinter)
   alias(libs.plugins.pambrose.testing)
   alias(libs.plugins.dokka)
+  alias(libs.plugins.kover)
   alias(libs.plugins.maven.publish)
 }
 
-// Update version refs in README.md and website/srcref/docs/{api,getting-started}.md as well
-version = findProperty("overrideVersion")?.toString() ?: "2.0.9"
-group = "com.pambrose"
+// Version and group are defined in gradle.properties; also update version refs in README.md and website/srcref/docs/{api,getting-started}.md
+findProperty("overrideVersion")?.toString()?.let { version = it }
 
 val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
 val releaseDate = (findProperty("releaseDate") as? String) ?: LocalDate.now().format(formatter)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,8 @@
 # Update version refs in README.md and website/srcref/docs/{api,getting-started}.md as well
 group=com.pambrose
 version=2.0.10
+releaseDate=04/25/2026
+
 kotlin.code.style=official
 org.gradle.configuration-cache=true
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
+# Update version refs in README.md and website/srcref/docs/{api,getting-started}.md as well
+group=com.pambrose
+version=2.0.10
 kotlin.code.style=official
 org.gradle.configuration-cache=true
 org.gradle.caching=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlin = "2.3.21"
 buildconfig = "6.0.9"
 gradle-plugins = "1.0.14"
 dokka = "2.2.0"
+kover = "0.9.8"
 maven-publish = "0.36.0"
 
 # Libraries
@@ -68,6 +69,7 @@ buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 pambrose-stable-versions = { id = "com.pambrose.stable-versions", version.ref = "gradle-plugins" }
 pambrose-kotlinter = { id = "com.pambrose.kotlinter", version.ref = "gradle-plugins" }

--- a/src/test/kotlin/com/pambrose/srcref/core/FetchContentTest.kt
+++ b/src/test/kotlin/com/pambrose/srcref/core/FetchContentTest.kt
@@ -1,0 +1,168 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.pambrose.srcref.core
+
+import com.pambrose.srcref.ContentCache
+import com.pambrose.srcref.ContentCache.Companion.contentCache
+import com.pambrose.srcref.ContentCache.Companion.fetchContent
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.header
+import io.ktor.server.response.respondBytes
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Exercises [ContentCache.Companion.fetchContent] against a real local HTTP server,
+ * since the underlying client is hard-coded inside the companion and cannot be injected.
+ */
+class FetchContentTest :
+  StringSpec(
+    {
+      lateinit var server: EmbeddedServer<*, *>
+      var port = 0
+
+      val etag = AtomicReference("")
+      val contentType = AtomicReference("text/plain; charset=UTF-8")
+      val body = AtomicReference("alpha\nbeta\ngamma")
+      val sendOversizedBody = AtomicReference(false)
+
+      beforeSpec {
+        server =
+          embeddedServer(CIO, port = 0) {
+            routing {
+              get("/file") {
+                etag.get().takeIf { it.isNotEmpty() }?.let {
+                  call.response.header(HttpHeaders.ETag, it)
+                  if (call.request.headers[HttpHeaders.IfNoneMatch] == it) {
+                    call.respondBytes(ByteArray(0), status = HttpStatusCode.NotModified)
+                    return@get
+                  }
+                }
+                val ct = ContentType.parse(contentType.get())
+                if (sendOversizedBody.get()) {
+                  // Allocate 6 MB so Content-Length comfortably exceeds the 5 MB max-length cap.
+                  call.respondBytes(ByteArray(6 * 1_048_576) { 'a'.code.toByte() }, ct)
+                } else {
+                  call.respondText(body.get(), ct)
+                }
+              }
+            }
+          }
+        server.start(wait = false)
+        port = runBlocking { server.engine.resolvedConnectors().first().port }
+      }
+
+      afterSpec {
+        server.stop(0, 0)
+      }
+
+      fun reset(
+        etagVal: String = "",
+        contentTypeVal: String = "text/plain; charset=UTF-8",
+        bodyVal: String = "alpha\nbeta\ngamma",
+        oversized: Boolean = false,
+      ) {
+        etag.set(etagVal)
+        contentType.set(contentTypeVal)
+        body.set(bodyVal)
+        sendOversizedBody.set(oversized)
+      }
+
+      "fetchContent caches by ETag and returns lines" {
+        reset(etagVal = "\"v1\"")
+        val url = "http://localhost:$port/file?cache-etag"
+        contentCache.remove(url)
+        val lines = fetchContent(url)
+        lines shouldBe listOf("alpha", "beta", "gamma")
+        val cached = contentCache[url]
+        cached shouldNotBe null
+        cached!!.etag shouldBe "\"v1\""
+        cached.pageLines shouldBe listOf("alpha", "beta", "gamma")
+      }
+
+      "fetchContent without ETag does not populate cache" {
+        reset(etagVal = "")
+        val url = "http://localhost:$port/file?no-etag"
+        contentCache.remove(url)
+        val lines = fetchContent(url)
+        lines shouldBe listOf("alpha", "beta", "gamma")
+        contentCache[url] shouldBe null
+      }
+
+      "fetchContent returns cached value on 304" {
+        reset(etagVal = "\"v304\"")
+        val url = "http://localhost:$port/file?cond-get"
+        contentCache.remove(url)
+
+        fetchContent(url)
+        val firstHits = contentCache[url]!!.hits
+
+        val second = fetchContent(url)
+        second shouldBe listOf("alpha", "beta", "gamma")
+        contentCache[url]!!.hits shouldBe firstHits + 1
+      }
+
+      "fetchContent rejects binary content type (image/png)" {
+        reset(contentTypeVal = "image/png")
+        val url = "http://localhost:$port/file?image"
+        contentCache.remove(url)
+        shouldThrow<IllegalArgumentException> {
+          fetchContent(url)
+        }.message shouldContain "Invalid content type"
+      }
+
+      "fetchContent rejects application/* content type" {
+        reset(contentTypeVal = "application/octet-stream")
+        val url = "http://localhost:$port/file?app"
+        contentCache.remove(url)
+        shouldThrow<IllegalArgumentException> {
+          fetchContent(url)
+        }.message shouldContain "Invalid content type"
+      }
+
+      "fetchContent accepts non-text content type with warning" {
+        // "weird/thing" is neither invalid nor text/* — should warn but proceed.
+        reset(contentTypeVal = "weird/thing")
+        val url = "http://localhost:$port/file?weird"
+        contentCache.remove(url)
+        val lines = fetchContent(url)
+        lines shouldBe listOf("alpha", "beta", "gamma")
+      }
+
+      "fetchContent throws when Content-Length exceeds maximum" {
+        reset(oversized = true)
+        val url = "http://localhost:$port/file?too-large"
+        contentCache.remove(url)
+        shouldThrow<IllegalArgumentException> {
+          fetchContent(url)
+        }.message shouldContain "exceeds maximum length"
+      }
+    },
+  )

--- a/src/test/kotlin/com/pambrose/srcref/core/UrlsTest.kt
+++ b/src/test/kotlin/com/pambrose/srcref/core/UrlsTest.kt
@@ -141,5 +141,45 @@ class UrlsTest :
         url shouldContain "problem"
         msg shouldContain "Missing: repo value"
       }
+
+      "githubRangeUrl with missing path returns problem URL" {
+        val params =
+          mapOf(
+            "account" to "u",
+            "repo" to "r",
+            "branch" to "main",
+            "path" to "",
+            "bregex" to "x",
+          )
+        val (url, msg) = githubRangeUrl(params, "http://localhost:8080")
+        url shouldContain "problem"
+        msg shouldContain "Missing: path value"
+      }
+
+      "githubRangeUrl with blank branch returns problem URL" {
+        val params =
+          mapOf(
+            "account" to "u",
+            "repo" to "r",
+            "branch" to "",
+            "path" to "f.kt",
+            "bregex" to "x",
+          )
+        val (url, msg) = githubRangeUrl(params, "http://localhost:8080")
+        url shouldContain "problem"
+        msg shouldContain "Missing: branch value"
+      }
+
+      "githubRangeUrl propagates the request prefix into the problem URL" {
+        val params = mapOf("account" to "u", "repo" to "")
+        val (url, _) = githubRangeUrl(params, "https://example.test")
+        url shouldStartWith "https://example.test/problem?"
+      }
+
+      "githubRangeUrl includes the original params in the problem query string" {
+        val params = mapOf("account" to "alice", "repo" to "")
+        val (url, _) = githubRangeUrl(params, "http://localhost:8080")
+        url shouldContain "account=alice"
+      }
     },
   )

--- a/src/test/kotlin/com/pambrose/srcref/integration/RoutesIntegrationTest.kt
+++ b/src/test/kotlin/com/pambrose/srcref/integration/RoutesIntegrationTest.kt
@@ -16,6 +16,8 @@
 
 package com.pambrose.srcref.integration
 
+import com.pambrose.srcref.ContentCache.CacheContent
+import com.pambrose.srcref.ContentCache.Companion.contentCache
 import com.pambrose.srcref.module
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -105,6 +107,43 @@ class RoutesIntegrationTest :
             status shouldBe HttpStatusCode.OK
             bodyAsText() shouldContain "Cache Size"
           }
+        }
+      }
+
+      "GET /cache renders populated entries with table" {
+        val rawUrl = "https://raw.githubusercontent.com/u/r/main/file.kt"
+        val shortEtagUrl = "https://example.com/short-etag-cache-test"
+        val longEtagUrl = "https://example.com/long-etag-cache-test"
+        val longEtag = "\"abcdefghijklmnopqrstuvwxyz1234567890\""
+        try {
+          contentCache[rawUrl] =
+            CacheContent(pageLines = listOf("a", "b", "c"), etag = "\"short\"", contentLength = 12)
+              .apply { markReferenced() }
+          contentCache[shortEtagUrl] =
+            CacheContent(pageLines = listOf("x"), etag = "\"e\"", contentLength = 1)
+          contentCache[longEtagUrl] =
+            CacheContent(pageLines = listOf("y"), etag = longEtag, contentLength = 1)
+
+          testApplication {
+            application { module() }
+            client.get("/cache").apply {
+              status shouldBe HttpStatusCode.OK
+              val body = bodyAsText()
+              body shouldContain "cachetable"
+              // Raw GitHub prefix is stripped from the URL display column
+              body shouldContain "/u/r/main/file.kt"
+              body shouldNotContain "raw.githubusercontent.com"
+              // Long etags get truncated with an ellipsis
+              body shouldContain "..."
+              // Both other test URLs render
+              body shouldContain shortEtagUrl
+              body shouldContain longEtagUrl
+            }
+          }
+        } finally {
+          contentCache.remove(rawUrl)
+          contentCache.remove(shortEtagUrl)
+          contentCache.remove(longEtagUrl)
         }
       }
 

--- a/website/srcref/docs/api.md
+++ b/website/srcref/docs/api.md
@@ -13,7 +13,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
 
     ```kotlin
     dependencies {
-        implementation("com.pambrose:srcref:2.0.9")
+        implementation("com.pambrose:srcref:2.0.10")
     }
     ```
 
@@ -21,7 +21,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
 
     ```groovy
     dependencies {
-        implementation 'com.pambrose:srcref:2.0.9'
+        implementation 'com.pambrose:srcref:2.0.10'
     }
     ```
 
@@ -31,7 +31,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
     <dependency>
         <groupId>com.pambrose</groupId>
         <artifactId>srcref</artifactId>
-        <version>2.0.9</version>
+        <version>2.0.10</version>
     </dependency>
     ```
 

--- a/website/srcref/docs/getting-started.md
+++ b/website/srcref/docs/getting-started.md
@@ -67,7 +67,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
 
     ```kotlin
     dependencies {
-        implementation("com.pambrose:srcref:2.0.9")
+        implementation("com.pambrose:srcref:2.0.10")
     }
     ```
 
@@ -75,7 +75,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
 
     ```groovy
     dependencies {
-        implementation 'com.pambrose:srcref:2.0.9'
+        implementation 'com.pambrose:srcref:2.0.10'
     }
     ```
 
@@ -85,7 +85,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
     <dependency>
         <groupId>com.pambrose</groupId>
         <artifactId>srcref</artifactId>
-        <version>2.0.9</version>
+        <version>2.0.10</version>
     </dependency>
     ```
 


### PR DESCRIPTION
## Summary
- Add Kover coverage plugin with broader test coverage (FetchContent, Urls, integration paths)
- Switch Gradle property reads to `providers.gradleProperty()` for configuration-cache compatibility
- Move `version`, `group`, and `releaseDate` into `gradle.properties` (single source of truth; Makefile no longer pins `-PreleaseDate`)
- Wire up Codecov: workflow now runs `koverXmlReport` and uploads the report; README gets a Codecov badge

## Test plan
- [ ] CI Tests workflow passes on this PR
- [ ] Codecov upload step succeeds (requires `CODECOV_TOKEN` repo secret)
- [ ] Coverage badge in README renders after merge to master
- [ ] `./gradlew properties` reports `version=2.0.10`, `group=com.pambrose`, `releaseDate=04/25/2026`
- [ ] `./gradlew build -PoverrideVersion=2.0.10-SNAPSHOT` overrides version correctly
- [ ] `make build` succeeds without `-PreleaseDate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)