### PR TITLE
Fix Makefile correctness and parsing issues (#38)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
-VERSION=$(shell grep '^version=' gradle.properties | head -1 | cut -d= -f2)
+VERSION=$(shell awk -F= '/^version[[:space:]]*=/ {gsub(/[[:space:]]/,"",$$2); print $$2; exit}' gradle.properties)
+
+.PHONY: default build-all stop clean build local-build tests local-tests run refresh \
+	fatjar uber run-docker build-docker docker-push release deploy do-log dist stage \
+	purge versioncheck kdocs coverage coverage-xml coverage-verify clean-docs site \
+	publish-local publish-local-snapshot check-gpg-env publish-snapshot \
+	publish-maven-central upgrade-wrapper
 
 default: versioncheck
+
+.NOTPARALLEL: build-all release
 
 build-all: clean stage
 
@@ -10,10 +18,10 @@ stop:
 clean:
 	./gradlew clean
 
-build:	clean
+build:
 	./gradlew build -xtest
 
-local-build: clean
+local-build:
 	./gradlew build -PuseMavenLocal=true -xtest
 
 tests:
@@ -31,24 +39,24 @@ refresh:
 fatjar: build
 	./gradlew buildFatJar
 
-uber: uberjar
+uber: fatjar
 	java -jar build/libs/srcref-all.jar
 
 run-docker:
-	docker run --rm --env-file=docker_env_vars -p 8080:8080 pambrose/srcref:${VERSION}
+	docker run --rm --env-file=docker_env_vars -p 8080:8080 pambrose/srcref:$(VERSION)
 
-build-docker:
-	docker build -t pambrose/srcref:${VERSION} .
+build-docker: build
+	docker build -t pambrose/srcref:$(VERSION) .
 
 PLATFORMS := linux/amd64,linux/arm64/v8
 IMAGE_NAME := pambrose/srcref
 
-docker-push:
+docker-push: build-docker
 	# prepare multiarch
 	docker buildx use buildx 2>/dev/null || docker buildx create --use --name=buildx
-	docker buildx build --platform ${PLATFORMS} --push -t ${IMAGE_NAME}:latest -t ${IMAGE_NAME}:${VERSION} .
+	docker buildx build --platform $(PLATFORMS) --push -t $(IMAGE_NAME):latest -t $(IMAGE_NAME):$(VERSION) .
 
-release: clean build build-docker docker-push
+release: docker-push
 
 deploy:
 	./secrets/deploy-app.sh
@@ -64,7 +72,7 @@ stage:
 	./gradlew stage
 
 purge:
-	 heroku builds:cache:purge -a srcref --confirm srcref
+	heroku builds:cache:purge -a srcref --confirm srcref
 
 versioncheck:
 	./gradlew dependencyUpdates --no-configuration-cache
@@ -96,7 +104,8 @@ publish-local-snapshot:
 
 GPG_ENV = \
 	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
-	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)
+	ORG_GRADLE_PROJECT_signingInMemoryKeyId="$$GPG_SIGNING_KEY_ID" \
+	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword="$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)"
 
 check-gpg-env:
 	@if [ -z "$$GPG_SIGNING_KEY_ID" ]; then \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Update version refs in README.md and website/srcref/docs/{api,getting-started}.md as well
 group=com.pambrose
 version=2.0.10
-releaseDate=04/25/2026
+releaseDate=05/02/2026
 
 kotlin.code.style=official
 org.gradle.configuration-cache=true


### PR DESCRIPTION
## Summary
- Quote `signingInMemoryKeyPassword` in `GPG_ENV` so passwords with whitespace/metacharacters don't break the inline env vars
- Add `.NOTPARALLEL` for `release`/`build-all` and explicit `build-docker: build` / `docker-push: build-docker` prerequisites so `make -j release` is safe
- Drop forced `clean` prerequisite from `build` and `local-build` to allow Gradle's incremental build to do its job (notably speeds up `make uber`)
- Switch `VERSION` parser from `grep | head | cut` to `awk` so `version = 2.0.10` (with surrounding whitespace) still resolves correctly
- Normalize the tab-after-`build:` to a plain target line for style consistency
- Bump `releaseDate` to 05/02/2026

## Test plan
- [ ] `make` (default → `versioncheck`) still runs
- [ ] `make build` succeeds and does not run `clean` first
- [ ] `make -n release` shows ordered build → build-docker → docker-push steps
- [ ] `make -n run-docker` resolves `$(VERSION)` to `2.0.10`
- [ ] `make publish-snapshot` / `publish-maven-central` still find the GPG key + keychain password

🤖 Generated with [Claude Code](https://claude.com/claude-code)