### PR TITLE
Tune Codecov config, drop mavenLocal gate, bump deps (#39)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,9 +130,9 @@ Published to Maven Central as `com.pambrose:srcref` via the vanniktech maven-pub
 Dokka generates the javadoc jar from KDoc comments. Signing uses in-memory GPG keys via `signingInMemoryKey`,
 `signingInMemoryKeyId`, and `signingInMemoryKeyPassword` Gradle properties.
 
-- `make publish-local` — publish to `~/.m2/repository` for local testing. To consume locally-published
-  artifacts in another build, run with `-PuseMavenLocal=true` (the `mavenLocal()` repo is gated on this
-  property in `settings.gradle.kts`).
+- `make publish-local` — publish to `~/.m2/repository` for local testing. Note: this build only resolves from
+  `mavenCentral()` (see `settings.gradle.kts`); to consume locally-published artifacts, add `mavenLocal()` to the
+  consuming build's repositories.
 - `make publish-maven-central` — publish and release to Maven Central.
 - `make kdocs` — generate KDoc HTML documentation to `build/dokka/html/`.
 

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,8 @@ clean:
 build:
 	./gradlew build -xtest
 
-local-build:
-	./gradlew build -PuseMavenLocal=true -xtest
-
 tests:
 	./gradlew --rerun-tasks check
-
-local-tests:
-	./gradlew --rerun-tasks -PuseMavenLocal=true check
 
 run:
 	./gradlew run

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+codecov:
+  require_ci_to_pass: true
+
+github_checks:
+  annotations: false
+
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        target: 70%
+        threshold: 1%
+        informational: true
+
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+  require_changes: true
+
+ignore:
+  - "**/BuildConfig.kt"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Update version refs in README.md and website/srcref/docs/{api,getting-started}.md as well
 group=com.pambrose
 version=2.0.10
-releaseDate=05/02/2026
+releaseDate=05/03/2026
 
 kotlin.code.style=official
 org.gradle.configuration-cache=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,9 +13,9 @@ dropwizard = "4.2.38"
 kotest = "6.1.11"
 ktor = "3.4.3"
 logback = "1.5.32"
-logging = "8.0.01"
+logging = "8.0.02"
 text = "1.15.0"
-utils = "2.8.1"
+utils = "2.8.2"
 
 [libraries]
 # Kotlin

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,9 +13,6 @@ dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
     mavenCentral()
-    if (providers.gradleProperty("useMavenLocal").orNull == "true") {
-      mavenLocal()
-    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Tighten and clean up `codecov.yml`: require CI to pass, disable check annotations, set explicit precision/round, tighten project threshold to 0.5%, mark patch coverage informational, drop empty `flags` from comment layout, and ignore `BuildConfig.kt`.
- Remove the `-PuseMavenLocal=true` flag and the `local-build` / `local-tests` Make targets. The build now resolves only from `mavenCentral()`; consumers that want locally-published artifacts should add `mavenLocal()` to their own build.
- Bump `core-utils` 2.8.1 → 2.8.2 and `kotlin-logging` 8.0.01 → 8.0.02.
- Update `releaseDate` in `gradle.properties`.

## Test plan
- [ ] `./gradlew build` succeeds against `mavenCentral()` only
- [ ] `./gradlew check` passes
- [ ] `./gradlew dependencyUpdates` resolves `core-utils:2.8.2` cleanly
- [ ] Codecov status check appears on the PR with the new config (no flags, no inline annotations, patch coverage marked informational)

🤖 Generated with [Claude Code](https://claude.com/claude-code)