### PR TITLE
Prep 2.0.10 docs (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project. Format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.0.10](https://github.com/pambrose/srcref/releases/tag/2.0.10) — 2026-05-03
+
+- Bump Gradle to 9.5, fix `releaseDate` format in Makefile, and update docs edit URI
+- Add Kover coverage with Codecov reporting ([#37](https://github.com/pambrose/srcref/pull/37))
+- Fix Makefile correctness and parsing issues ([#38](https://github.com/pambrose/srcref/pull/38))
+- Tune Codecov config: require CI to pass, disable check annotations, set explicit precision/round, tighten project threshold to 0.5%, mark patch coverage informational, drop empty `flags` from comment layout, and ignore `BuildConfig.kt` ([#39](https://github.com/pambrose/srcref/pull/39))
+- Drop `-PuseMavenLocal` flag and `local-build` / `local-tests` Make targets; build now resolves only from `mavenCentral()` ([#39](https://github.com/pambrose/srcref/pull/39))
+- Bump dependencies: `common-utils` 2.8.1 → 2.8.2, `kotlin-logging` 8.0.01 → 8.0.02 ([#39](https://github.com/pambrose/srcref/pull/39))
+
+**Full Changelog**: https://github.com/pambrose/srcref/compare/2.0.9...2.0.10
+
 ## [2.0.9](https://github.com/pambrose/srcref/releases/tag/2.0.9) — 2026-04-25
 
 - Bump version to 2.0.9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,10 @@ Tests in `src/test/kotlin/` use Kotest `StringSpec` with JUnit5 runner:
 - **BugFixTests.kt** — Regression tests: ETag edge cases, daemon thread, robots.txt, occurrence validation
 - **EndpointsTest.kt**, **CommonTest.kt**, **MainTest.kt** — Unit tests for utilities
 
+Coverage is reported to Codecov via Kover. Codecov behavior is configured in `codecov.yml`:
+project status uses `auto` target with a 0.5% threshold; patch status targets 70% but is
+informational (won't gate PRs); generated `BuildConfig.kt` is ignored.
+
 ## Code Style
 
 - Kotlinter (ktlint) for linting. Run `./gradlew formatKotlin` before committing.

--- a/README.md
+++ b/README.md
@@ -319,6 +319,9 @@ cd srcref
 # Run tests
 ./gradlew test
 
+# Generate coverage report (HTML at build/reports/kover/html/)
+make coverage
+
 # Start development server
 ./gradlew run
 ```
@@ -327,7 +330,7 @@ cd srcref
 
 ```bash
 # Create executable JAR
-make uberjar
+make uber
 
 # Build Docker image
 make build-docker

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,19 @@
 
 Full release notes for every published version, newest first. Mirrors https://github.com/pambrose/srcref/releases.
 
+## [v2.0.10](https://github.com/pambrose/srcref/releases/tag/2.0.10) — 2026-05-03
+
+## What's Changed
+
+- Bump Gradle to 9.5, fix `releaseDate` format in Makefile, and update docs edit URI
+- Add Kover coverage with Codecov reporting ([#37](https://github.com/pambrose/srcref/pull/37))
+- Fix Makefile correctness and parsing issues ([#38](https://github.com/pambrose/srcref/pull/38))
+- Tune Codecov config: require CI to pass, disable check annotations, set explicit precision/round, tighten project threshold to 0.5%, mark patch coverage informational, drop empty `flags` from comment layout, and ignore `BuildConfig.kt` ([#39](https://github.com/pambrose/srcref/pull/39))
+- Drop `-PuseMavenLocal` flag and `local-build` / `local-tests` Make targets; build now resolves only from `mavenCentral()` ([#39](https://github.com/pambrose/srcref/pull/39))
+- Bump dependencies: `common-utils` 2.8.1 → 2.8.2, `kotlin-logging` 8.0.01 → 8.0.02 ([#39](https://github.com/pambrose/srcref/pull/39))
+
+**Full Changelog**: https://github.com/pambrose/srcref/compare/2.0.9...2.0.10
+
 ## [v2.0.9](https://github.com/pambrose/srcref/releases/tag/2.0.9) — 2026-04-25
 
 ## What's Changed

--- a/llms.txt
+++ b/llms.txt
@@ -59,6 +59,7 @@ Available on Maven Central as `com.pambrose:srcref`. Licensed under Apache Licen
 - [GitHub Repository](https://github.com/pambrose/srcref): Source code and documentation
 - [Documentation Site](https://pambrose.github.io/srcref/): Zensical-based docs (getting started, query parameters, regex guide, API, advanced usage, deployment)
 - [KDoc API Reference](https://pambrose.github.io/srcref/api-docs/index.html): Generated via Dokka
+- [Coverage Report](https://codecov.io/gh/pambrose/srcref): Test coverage tracked via Kover and Codecov
 
 ## Optional
 


### PR DESCRIPTION
## Summary
- Add 2.0.10 (2026-05-03) section to `CHANGELOG.md` and `RELEASE_NOTES.md` covering the Gradle 9.5 bump, Kover + Codecov reporting (#37), Makefile correctness fixes (#38), and Codecov tuning + `mavenLocal`-gate removal + `common-utils` / `kotlin-logging` bumps (#39).
- Document Codecov configuration in `CLAUDE.md` Testing section.
- Add `make coverage` to README development setup; fix `make uberjar` → `make uber`.
- Add Codecov coverage report link to `llms.txt`.

## Test plan
- [ ] `CHANGELOG.md` and `RELEASE_NOTES.md` render correctly with the new 2.0.10 section
- [ ] README and llms.txt links resolve
- [ ] `make uber` and `make coverage` run cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)