### PR TITLE
Run uv lock from website project root in site Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,10 @@ kdocs:  ## Generate KDoc HTML documentation
 	./gradlew dokkaGeneratePublicationHtml
 
 check-site:  ## Check for outdated website dependencies
-	cd website/srcref && env -u VIRTUAL_ENV uv lock --upgrade --dry-run
+	cd website && env -u VIRTUAL_ENV uv lock --upgrade --dry-run
 
 upgrade-site:  ## Upgrade the website dependencies
-	cd website/srcref && env -u VIRTUAL_ENV uv lock --upgrade
+	cd website && env -u VIRTUAL_ENV uv lock --upgrade
 
 clean-site:  ## Remove generated docs site
 	rm -rf website/srcref/site


### PR DESCRIPTION
## Summary

The `check-site` and `upgrade-site` Makefile targets `cd website/srcref` before running `uv lock`, but the uv project (`pyproject.toml`, `uv.lock`) lives in `website/`, not `website/srcref/`. The commands only worked because uv walks up the directory tree to discover the project root.

This points both targets at `website/` directly, matching their original (pre-merge) form. The `site` target's `cd website/srcref` is left unchanged since that's the docs directory `zensical serve` runs from.

## Test plan

- `make check-site` resolves correctly from the repo root (`Resolved 12 packages`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)