### PR TITLE
Update version references to 2.1.0 across docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 All notable changes to this project. Format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [2.0.11](https://github.com/pambrose/srcref/releases/tag/2.0.11) — Unreleased
+## [2.1.0](https://github.com/pambrose/srcref/releases/tag/2.1.0) — Unreleased
 
+- Upgrade Gradle wrapper to 9.5.1 ([#45](https://github.com/pambrose/srcref/pull/45))
+- Upgrade dependencies: Kotlin 2.4.0-RC, Ktor 3.5.0, kotlin-logging 8.0.03, and website tooling (zensical 0.0.43)
+- Enable the Gradle daemon and parallel execution in `gradle.properties`
+- Add `check-site` / `upgrade-site` Makefile targets for managing website dependencies
 - Add detekt static analysis with baseline and Gradle integration ([#41](https://github.com/pambrose/srcref/pull/41))
 - Consolidate build literals and centralize toolchain versions in `gradle/libs.versions.toml`
 - Extract the `coverage-packages` Python report from the Makefile into `scripts/coverage_packages.py` so the recipe is a one-line invocation
 - Add `make help` target that auto-discovers `## description` annotations on Makefile targets and prints a colorized listing
 
-**Full Changelog**: https://github.com/pambrose/srcref/compare/2.0.10...2.0.11
+**Full Changelog**: https://github.com/pambrose/srcref/compare/2.0.10...2.1.0
 
 ## [2.0.10](https://github.com/pambrose/srcref/releases/tag/2.0.10) — 2026-05-03
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ informational (won't gate PRs); generated `BuildConfig.kt` is ignored.
 
 ## Version Management
 
-Version is defined in `gradle.properties` (`version=2.0.11`). The Makefile `VERSION` is derived automatically from
+Version is defined in `gradle.properties` (`version=2.1.0`). The Makefile `VERSION` is derived automatically from
 `gradle.properties`. The following must still be updated manually when changing the version:
 
 - `README.md` (Maven/Gradle dependency snippets and Kotlin version badge)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.pambrose/srcref)](https://central.sonatype.com/artifact/com.pambrose/srcref)
 [![Tests](https://img.shields.io/github/actions/workflow/status/pambrose/srcref/tests.yml?branch=master&label=tests)](https://github.com/pambrose/srcref/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/pambrose/srcref/branch/master/graph/badge.svg)](https://codecov.io/gh/pambrose/srcref)
-[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.21-red?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin version](https://img.shields.io/badge/kotlin-2.4.0--RC-red?logo=kotlin)](http://kotlinlang.org)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## Overview
@@ -102,7 +102,7 @@ _srcref_ URLs can be generated programmatically with the `srcrefUrl()` call. An 
 
 ```kotlin
 dependencies {
-   implementation("com.pambrose:srcref:2.0.11")
+   implementation("com.pambrose:srcref:2.1.0")
 }
 ```
 
@@ -113,7 +113,7 @@ dependencies {
 
 ```groovy
 dependencies {
-   implementation 'com.pambrose:srcref:2.0.11'
+   implementation 'com.pambrose:srcref:2.1.0'
 }
 ```
 
@@ -127,7 +127,7 @@ dependencies {
 <dependency>
    <groupId>com.pambrose</groupId>
    <artifactId>srcref</artifactId>
-   <version>2.0.11</version>
+   <version>2.1.0</version>
 </dependency>
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,16 +2,20 @@
 
 Full release notes for every published version, newest first. Mirrors https://github.com/pambrose/srcref/releases.
 
-## [v2.0.11](https://github.com/pambrose/srcref/releases/tag/2.0.11) — Unreleased
+## [v2.1.0](https://github.com/pambrose/srcref/releases/tag/2.1.0) — Unreleased
 
 ## What's Changed
 
+- Upgrade Gradle wrapper to 9.5.1 ([#45](https://github.com/pambrose/srcref/pull/45))
+- Upgrade dependencies: Kotlin 2.4.0-RC, Ktor 3.5.0, kotlin-logging 8.0.03, and website tooling (zensical 0.0.43)
+- Enable the Gradle daemon and parallel execution in `gradle.properties`
+- Add `check-site` / `upgrade-site` Makefile targets for managing website dependencies
 - Add detekt static analysis with baseline and Gradle integration ([#41](https://github.com/pambrose/srcref/pull/41))
 - Consolidate build literals and centralize toolchain versions in `gradle/libs.versions.toml`
 - Extract the `coverage-packages` Python report from the Makefile into `scripts/coverage_packages.py` so the recipe is a one-line invocation
 - Add `make help` target that auto-discovers `## description` annotations on Makefile targets and prints a colorized listing
 
-**Full Changelog**: https://github.com/pambrose/srcref/compare/2.0.10...2.0.11
+**Full Changelog**: https://github.com/pambrose/srcref/compare/2.0.10...2.1.0
 
 ## [v2.0.10](https://github.com/pambrose/srcref/releases/tag/2.0.10) — 2026-05-03
 

--- a/website/srcref/docs/api.md
+++ b/website/srcref/docs/api.md
@@ -13,7 +13,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
 
     ```kotlin
     dependencies {
-        implementation("com.pambrose:srcref:2.0.11")
+        implementation("com.pambrose:srcref:2.1.0")
     }
     ```
 
@@ -21,7 +21,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
 
     ```groovy
     dependencies {
-        implementation 'com.pambrose:srcref:2.0.11'
+        implementation 'com.pambrose:srcref:2.1.0'
     }
     ```
 
@@ -31,7 +31,7 @@ the `Api.srcrefUrl()` function for generating srcref URLs programmatically.
     <dependency>
         <groupId>com.pambrose</groupId>
         <artifactId>srcref</artifactId>
-        <version>2.0.11</version>
+        <version>2.1.0</version>
     </dependency>
     ```
 

--- a/website/srcref/docs/getting-started.md
+++ b/website/srcref/docs/getting-started.md
@@ -67,7 +67,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
 
     ```kotlin
     dependencies {
-        implementation("com.pambrose:srcref:2.0.11")
+        implementation("com.pambrose:srcref:2.1.0")
     }
     ```
 
@@ -75,7 +75,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
 
     ```groovy
     dependencies {
-        implementation 'com.pambrose:srcref:2.0.11'
+        implementation 'com.pambrose:srcref:2.1.0'
     }
     ```
 
@@ -85,7 +85,7 @@ Add `&edit` to any srcref URL to open it in the editor with all fields pre-fille
     <dependency>
         <groupId>com.pambrose</groupId>
         <artifactId>srcref</artifactId>
-        <version>2.0.11</version>
+        <version>2.1.0</version>
     </dependency>
     ```
 


### PR DESCRIPTION
## Summary

`gradle.properties` was bumped to `2.1.0`, but the version references that must be updated manually (per CLAUDE.md) were left at `2.0.11`. This brings them all in sync:

- **README.md** — 3 dependency snippets → `2.1.0`; Kotlin badge → `2.4.0-RC`
- **website/srcref/docs/api.md** — 3 dependency snippets → `2.1.0`
- **website/srcref/docs/getting-started.md** — 3 dependency snippets → `2.1.0`
- **CLAUDE.md** — Version Management note → `version=2.1.0`
- **CHANGELOG.md** / **RELEASE_NOTES.md** — renamed the unreleased `2.0.11` section to `2.1.0` (header, tag link, compare link) and added entries for the Gradle 9.5.1 upgrade, dependency bumps, daemon/parallel flags, and the new site targets

The `2.0.11` section was never released (it was the in-progress section), so renaming it to `2.1.0` rather than adding a new section keeps the history clean.

## Test plan

- `grep` confirms no stale `2.0.11` references remain in the affected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)