### PR TITLE
Bump Kotlin RC2, Dropwizard, Logback, and logging versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ gradle-wrapper = "9.5.1"
 jvm = "17"
 
 # Plugins
-kotlin = "2.4.0-RC"
+kotlin = "2.4.0-RC2"
 buildconfig = "6.0.9"
 detekt = "2.0.0-alpha.3"
 gradle-plugins = "1.0.14"
@@ -14,11 +14,11 @@ maven-publish = "0.36.0"
 
 # Libraries
 coroutines = "1.11.0"
-dropwizard = "4.2.38"
+dropwizard = "4.2.39"
 kotest = "6.1.11"
 ktor = "3.5.0"
-logback = "1.5.32"
-logging = "8.0.03"
+logback = "1.5.33"
+logging = "8.0.4"
 text = "1.15.0"
 utils = "2.8.2"
 


### PR DESCRIPTION
## Summary

Bump several dependency versions in `gradle/libs.versions.toml`:

- `kotlin`: 2.4.0-RC → 2.4.0-RC2
- `dropwizard`: 4.2.38 → 4.2.39
- `logback`: 1.5.32 → 1.5.33
- `logging`: 8.0.03 → 8.0.4

## Test plan

- [ ] `./gradlew build` succeeds with the updated versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)