### PR TITLE
Finalize 2.1.0 release docs and bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@
 
 All notable changes to this project. Format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [2.1.0](https://github.com/pambrose/srcref/releases/tag/2.1.0) — Unreleased
+## [2.1.0](https://github.com/pambrose/srcref/releases/tag/2.1.0) — 2026-06-03
 
 - Upgrade Gradle wrapper to 9.5.1 ([#45](https://github.com/pambrose/srcref/pull/45))
-- Upgrade dependencies: Kotlin 2.4.0-RC, Ktor 3.5.0, kotlin-logging 8.0.03, and website tooling (zensical 0.0.43)
+- Upgrade dependencies: Kotlin 2.4.0, Ktor 3.5.0, common-utils 2.9.0, kotlin-logging 8.0.4, Dropwizard 4.2.39, Logback 1.5.34, and website tooling (zensical 0.0.43) ([#49](https://github.com/pambrose/srcref/pull/49))
 - Enable the Gradle daemon and parallel execution in `gradle.properties`
 - Add `check-site` / `upgrade-site` Makefile targets for managing website dependencies
+- Abstract website directories to `WEBSITE_DIR` and `SITE_DIR` in the Makefile ([#48](https://github.com/pambrose/srcref/pull/48))
+- Run `uv lock` from the website project root in site Makefile targets ([#46](https://github.com/pambrose/srcref/pull/46))
 - Add detekt static analysis with baseline and Gradle integration ([#41](https://github.com/pambrose/srcref/pull/41))
-- Consolidate build literals and centralize toolchain versions in `gradle/libs.versions.toml`
+- Consolidate build literals and centralize toolchain versions in `gradle/libs.versions.toml` ([#42](https://github.com/pambrose/srcref/pull/42))
 - Extract the `coverage-packages` Python report from the Makefile into `scripts/coverage_packages.py` so the recipe is a one-line invocation
 - Add `make help` target that auto-discovers `## description` annotations on Makefile targets and prints a colorized listing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,8 @@ Run a single named test (Kotest string spec name):
 Makefile shortcuts: `make build`, `make tests`, `make run`, `make uber`, `make release`, `make deploy`,
 `make kdocs`, `make coverage`, `make coverage-xml`, `make coverage-verify`, `make coverage-packages`
 (per-package coverage summary via `scripts/coverage_packages.py`), `make lint` (kotlinter + detekt),
-`make detekt-baseline`, `make publish-local`, `make publish-maven-central`. Run `make help` to list
+`make detekt-baseline`, `make publish-local`, `make publish-maven-central`, `make check-site`,
+`make upgrade-site` (check for / apply website dependency updates). Run `make help` to list
 all annotated targets with descriptions.
 Default `make` target runs `./gradlew dependencyUpdates` to check for outdated dependencies.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.pambrose/srcref)](https://central.sonatype.com/artifact/com.pambrose/srcref)
 [![Tests](https://img.shields.io/github/actions/workflow/status/pambrose/srcref/tests.yml?branch=master&label=tests)](https://github.com/pambrose/srcref/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/pambrose/srcref/branch/master/graph/badge.svg)](https://codecov.io/gh/pambrose/srcref)
-[![Kotlin version](https://img.shields.io/badge/kotlin-2.4.0--RC-red?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin version](https://img.shields.io/badge/kotlin-2.4.0-red?logo=kotlin)](http://kotlinlang.org)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## Overview

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,16 +2,18 @@
 
 Full release notes for every published version, newest first. Mirrors https://github.com/pambrose/srcref/releases.
 
-## [v2.1.0](https://github.com/pambrose/srcref/releases/tag/2.1.0) — Unreleased
+## [v2.1.0](https://github.com/pambrose/srcref/releases/tag/2.1.0) — 2026-06-03
 
 ## What's Changed
 
 - Upgrade Gradle wrapper to 9.5.1 ([#45](https://github.com/pambrose/srcref/pull/45))
-- Upgrade dependencies: Kotlin 2.4.0-RC, Ktor 3.5.0, kotlin-logging 8.0.03, and website tooling (zensical 0.0.43)
+- Upgrade dependencies: Kotlin 2.4.0, Ktor 3.5.0, common-utils 2.9.0, kotlin-logging 8.0.4, Dropwizard 4.2.39, Logback 1.5.34, and website tooling (zensical 0.0.43) ([#49](https://github.com/pambrose/srcref/pull/49))
 - Enable the Gradle daemon and parallel execution in `gradle.properties`
 - Add `check-site` / `upgrade-site` Makefile targets for managing website dependencies
+- Abstract website directories to `WEBSITE_DIR` and `SITE_DIR` in the Makefile ([#48](https://github.com/pambrose/srcref/pull/48))
+- Run `uv lock` from the website project root in site Makefile targets ([#46](https://github.com/pambrose/srcref/pull/46))
 - Add detekt static analysis with baseline and Gradle integration ([#41](https://github.com/pambrose/srcref/pull/41))
-- Consolidate build literals and centralize toolchain versions in `gradle/libs.versions.toml`
+- Consolidate build literals and centralize toolchain versions in `gradle/libs.versions.toml` ([#42](https://github.com/pambrose/srcref/pull/42))
 - Extract the `coverage-packages` Python report from the Makefile into `scripts/coverage_packages.py` so the recipe is a one-line invocation
 - Add `make help` target that auto-discovers `## description` annotations on Makefile targets and prints a colorized listing
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ gradle-wrapper = "9.5.1"
 jvm = "17"
 
 # Plugins
-kotlin = "2.4.0-RC2"
+kotlin = "2.4.0"
 buildconfig = "6.0.9"
 detekt = "2.0.0-alpha.3"
 gradle-plugins = "1.0.14"
@@ -17,10 +17,10 @@ coroutines = "1.11.0"
 dropwizard = "4.2.39"
 kotest = "6.1.11"
 ktor = "3.5.0"
-logback = "1.5.33"
+logback = "1.5.34"
 logging = "8.0.4"
 text = "1.15.0"
-utils = "2.8.2"
+utils = "2.9.0"
 
 [libraries]
 # Kotlin

--- a/src/main/resources/public/llms.txt
+++ b/src/main/resources/public/llms.txt
@@ -1,80 +1,67 @@
 # srcref
 
-> Dynamic GitHub permalinks using regex patterns instead of fixed line numbers.
-
-srcref is a web service that generates GitHub permalinks where the target lines are
-determined dynamically by regex at click time. Instead of hardcoding line numbers
-that break when code changes, srcref finds lines matching your regex patterns and
-redirects to the correct GitHub URL. Live at https://www.srcref.com.
+> srcref is a web service that generates dynamic GitHub permalinks using regex patterns.
+> Instead of linking to fixed line numbers that break when code changes, srcref uses regex
+> to find the target lines dynamically. Live at https://www.srcref.com.
 
 ## How It Works
 
-1. You create a srcref URL specifying a GitHub file and regex patterns for the begin/end lines.
-2. When someone clicks the URL, srcref fetches the current file content from GitHub.
-3. It searches the file for lines matching your regex patterns.
-4. It constructs a GitHub permalink with the correct line numbers and redirects (302) to it.
+srcref accepts query parameters specifying a GitHub file and regex patterns, then:
 
-## URL Parameters
+1. Fetches the file content (with ETag-based caching)
+2. Searches for regex matches to determine line numbers
+3. Redirects the browser to the corresponding GitHub permalink
 
-All parameters are passed as query strings to `/github`:
+Supports begin/end ranges, occurrence selection (Nth match), top-down/bottom-up search direction, and line offsets.
 
-| Parameter  | Description                          | Required |
-|------------|--------------------------------------|----------|
-| `account`  | GitHub account/org                   | Yes      |
-| `repo`     | Repository name                      | Yes      |
-| `branch`   | Branch name (default: master)        | Yes      |
-| `path`     | File path within repo                | Yes      |
-| `bregex`   | Begin line regex pattern             | Yes      |
-| `boccur`   | Begin occurrence (Nth match, default: 1) | Yes  |
-| `boffset`  | Begin line offset (default: 0)       | Yes      |
-| `btopd`    | Begin search top-down (default: true)| Yes      |
-| `eregex`   | End line regex pattern               | No       |
-| `eoccur`   | End occurrence (Nth match, default: 1) | No     |
-| `eoffset`  | End line offset (default: 0)         | No       |
-| `etopd`    | End search top-down (default: true)  | No       |
+## Query Parameters
 
-If end parameters are omitted, only a single line is highlighted.
+- `account`: GitHub account or organization name (required)
+- `repo`: Repository name (required)
+- `branch`: Branch name (default: "master")
+- `path`: File path in the repository (required)
+- `bregex`: Regex for the beginning line match (required)
+- `boccur`: Occurrence number for beginning match (default: 1)
+- `boffset`: Line offset from beginning match (default: 0)
+- `btopd`: Search direction for beginning match, true=top-down (default: true)
+- `eregex`: Regex for the ending line match (optional, omit for single-line highlight)
+- `eoccur`: Occurrence number for ending match (default: 1)
+- `eoffset`: Line offset from ending match (default: 0)
+- `etopd`: Search direction for ending match (default: true)
 
 ## Endpoints
 
-- `/edit` - Interactive form for creating srcref URLs
-- `/github?<params>` - Redirect to the computed GitHub permalink
-- `/github?<params>&edit` - Pre-fill the edit form with existing params
-- `/what` - Explanation of what srcref is and how it works
-- `/ping` - Health check (returns "pong")
-- `/version` - Version and build info
-- `/cache` - Cache status
+- [Edit Form](https://www.srcref.com/edit): Main form UI for creating srcref URLs
+- [GitHub Redirect](https://www.srcref.com/github): Generates and redirects to a GitHub permalink (requires query parameters)
+- [About](https://www.srcref.com/what): Information about srcref
+- [Health Check](https://www.srcref.com/ping): Returns "pong"
 
-## API Usage
+## Programmatic Usage
 
-srcref is available as a Maven Central dependency for programmatic use:
+Available as a Maven Central dependency for Kotlin/JVM projects:
 
 ```kotlin
-val url = Api.srcrefUrl(
-  account = "owner",
-  repo = "repo",
-  branch = "main",
-  path = "src/File.kt",
-  bregex = "fun main",
+val permalink = Api.srcrefUrl(
+    account = "pambrose",
+    repo = "srcref",
+    path = "src/main/kotlin/Main.kt",
+    beginRegex = "fun main",
+    endRegex = "embeddedServer"
 )
 ```
-
-## Example
-
-To highlight lines between `install\(CallLogging\)` and 6 lines past `install\(Compression\)`
-in a file:
-
-```
-https://www.srcref.com/github?account=pambrose&repo=srcref&branch=master&path=src/main/kotlin/com/pambrose/srcref/Main.kt&bregex=install%5C%28CallLogging%5C%29&boccur=1&boffset=0&btopd=true&eregex=install%5C%28Compression%5C%29&eoccur=1&eoffset=6&etopd=true
-```
-
-Regex values use Java's `java.util.regex.Pattern` syntax. Characters like `()`, `[]`,
-and `{}` need escaping with backslashes when you want their literal values.
 
 ## Dependency
 
 Available on Maven Central as `com.pambrose:srcref`. Licensed under Apache License 2.0.
 
-## Source Code
+## Documentation
 
-GitHub: https://github.com/pambrose/srcref
+- [GitHub Repository](https://github.com/pambrose/srcref): Source code and documentation
+- [Documentation Site](https://pambrose.github.io/srcref/): Zensical-based docs (getting started, query parameters, regex guide, API, advanced usage, deployment)
+- [KDoc API Reference](https://pambrose.github.io/srcref/api-docs/index.html): Generated via Dokka
+- [Coverage Report](https://codecov.io/gh/pambrose/srcref): Test coverage tracked via Kover and Codecov
+
+## Optional
+
+- [Cache Status](https://www.srcref.com/cache): Current cache statistics
+- [Version Info](https://www.srcref.com/version): Build version and release date


### PR DESCRIPTION
## Summary

Prepares the 2.1.0 release docs and finalizes dependency versions.

- Set the 2.1.0 release date to **2026-06-03** in `CHANGELOG.md` and `RELEASE_NOTES.md`
- Finalize the dependency list: Kotlin **2.4.0** (from RC2), common-utils **2.9.0**, kotlin-logging **8.0.4**, Dropwizard **4.2.39**, Logback **1.5.34**
- Add the #46/#48 Makefile changes to the changelog/release notes
- Bump `libs.versions.toml`: Kotlin RC2 → 2.4.0, Logback 1.5.33 → 1.5.34, common-utils 2.8.2 → 2.9.0
- Update the README Kotlin version badge to 2.4.0
- Document `make check-site` / `make upgrade-site` in `CLAUDE.md`
- Sync the served `src/main/resources/public/llms.txt` to the canonical root `llms.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)